### PR TITLE
Breathing code fix

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1077,7 +1077,7 @@
 	var/SA_para_min = 1
 	var/SA_sleep_min = 5
 	var/oxygen_used = 0
-	var/breath_pressure = (breath.total_moles()*R_IDEAL_GAS_EQUATION*T20C)/BREATH_VOLUME
+	var/breath_pressure = (breath.total_moles()*R_IDEAL_GAS_EQUATION*293.15)/BREATH_VOLUME
 
 	//Partial pressure of the O2 in our breath
 	var/O2_pp = (breath.oxygen/breath.total_moles())*breath_pressure

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1077,7 +1077,7 @@
 	var/SA_para_min = 1
 	var/SA_sleep_min = 5
 	var/oxygen_used = 0
-	var/breath_pressure = (breath.total_moles()*R_IDEAL_GAS_EQUATION*breath.temperature)/BREATH_VOLUME
+	var/breath_pressure = (breath.total_moles()*R_IDEAL_GAS_EQUATION*T20C)/BREATH_VOLUME
 
 	//Partial pressure of the O2 in our breath
 	var/O2_pp = (breath.oxygen/breath.total_moles())*breath_pressure

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1077,7 +1077,7 @@
 	var/SA_para_min = 1
 	var/SA_sleep_min = 5
 	var/oxygen_used = 0
-	var/breath_pressure = (breath.total_moles()*R_IDEAL_GAS_EQUATION*293.15)/BREATH_VOLUME
+	var/breath_pressure = (breath.total_moles()*R_IDEAL_GAS_EQUATION*T20C)/BREATH_VOLUME
 
 	//Partial pressure of the O2 in our breath
 	var/O2_pp = (breath.oxygen/breath.total_moles())*breath_pressure

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -153,7 +153,7 @@
 	var/SA_para_min = 1
 	var/SA_sleep_min = 5
 	var/oxygen_used = 0
-	var/breath_pressure = (breath.total_moles()*R_IDEAL_GAS_EQUATION*breath.temperature)/BREATH_VOLUME
+	var/breath_pressure = (breath.total_moles()*R_IDEAL_GAS_EQUATION*293.15)/BREATH_VOLUME //If there's a constant for room temperature replace 293.15 with that
 
 	var/O2_partialpressure = (breath.oxygen/breath.total_moles())*breath_pressure
 	var/Toxins_partialpressure = (breath.toxins/breath.total_moles())*breath_pressure

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -153,7 +153,7 @@
 	var/SA_para_min = 1
 	var/SA_sleep_min = 5
 	var/oxygen_used = 0
-	var/breath_pressure = (breath.total_moles()*R_IDEAL_GAS_EQUATION*293.15)/BREATH_VOLUME //If there's a constant for room temperature replace 293.15 with that
+	var/breath_pressure = (breath.total_moles()*R_IDEAL_GAS_EQUATION*T20C)/BREATH_VOLUME
 
 	var/O2_partialpressure = (breath.oxygen/breath.total_moles())*breath_pressure
 	var/Toxins_partialpressure = (breath.toxins/breath.total_moles())*breath_pressure


### PR DESCRIPTION
Higher temperature gases require higher pressures to take effect, lower temperature gases lower. At room temperature(20C or 293.15K) gases will behave as before. For example oxygen at room temperature still requires 16 kPa release pressure, but oxygen cooled to 263K will only require 15 kPa. Testing recommended, floating point calculations might cause unexpected results (eg. room temperature oxygen requiring more than 16kPa). If this happens, increasing the safe min/max values a little will probably fix it.

This is a quick and dirty fix, changing the safe min/max values to moles and replacing lines 156-160 accordingly would probably be a better idea.
