### PR TITLE
MoMMI fixes

### DIFF
--- a/code/modules/mob/living/silicon/mommi/death.dm
+++ b/code/modules/mob/living/silicon/mommi/death.dm
@@ -1,4 +1,6 @@
 /mob/living/silicon/robot/mommi/gib(var/animation = 1)
+	if(generated)
+		src.dust()
 	if(src.module && istype(src.module))
 		var/obj/item/found = locate(tool_state) in src.module.modules
 		if(!found && tool_state != src.module.emag)
@@ -6,10 +8,18 @@
 			drop_item()
 			if(TS && TS.loc)
 				TS.loc = src.loc
+
 	..()
 
 
 /mob/living/silicon/robot/mommi/dust(var/animation = 1)
+	if(src.module && istype(src.module)) //Drop what it's holding if it isn't a module
+		var/obj/item/found = locate(tool_state) in src.module.modules
+		if(!found && tool_state != src.module.emag)
+			var/obj/item/TS = tool_state
+			drop_item()
+			if(TS && TS.loc)
+				TS.loc = src.loc
 	if(mmi)
 		qdel(mmi)
 	..()

--- a/code/modules/mob/living/silicon/mommi/life.dm
+++ b/code/modules/mob/living/silicon/mommi/life.dm
@@ -292,7 +292,7 @@
 /mob/living/silicon/robot/mommi/proc/process_killswitch() //this proc is here to stop derelict mommis from getting on the station and shitting things up
 	if(killswitch) //sanity
 		if(src.z)  //If a mommi somehow escapes inside a locker, it'll get wrecked next tick life() processes
-			if(!(src.z == allowed_z))
+			if(!(src.z in allowed_z))
 				src.killswitch()
 				return
 			return
@@ -303,6 +303,6 @@
 
 /mob/living/silicon/robot/mommi/proc/killswitch()
  	src << "<span class= 'danger'> You have left the bounds of your operational area and your killswitch has been activated </span>"
- 	src.dust()
+ 	src.gib()
  	return
 

--- a/code/modules/mob/living/silicon/mommi/mommi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi.dm
@@ -11,7 +11,7 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 	icon_state = "mommi"
 	maxHealth = 45
 	health = 45
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE | PASSMOB
 	var/keeper=0 // 0 = No, 1 = Yes (Disables speech and common radio.)
 	var/picked = 0
 	var/subtype="keeper"
@@ -682,3 +682,24 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 
 	face_atom(A)
 	A.examine(src)
+
+
+/mob/living/silicon/robot/mommi/stripPanelUnequip(obj/item/what, mob/who, where)
+	if(src.keeper)
+		src << "Your laws prevent you from doing this"
+		return
+	else ..()
+
+/mob/living/silicon/robot/mommi/stripPanelEquip(obj/item/what, mob/who, where)
+	if(src.keeper)
+		src << "Your laws prevent you from doing this"
+		return
+	else ..()
+
+
+/mob/living/silicon/robot/mommi/start_pulling(var/atom/movable/AM)
+	if(istype(AM,/mob) && !ismommi(AM))
+		if(src.keeper)
+			src << "Your laws prevent you from doing this"
+			return
+	..(AM)

--- a/code/modules/mob/living/silicon/mommi/mommi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi.dm
@@ -26,7 +26,7 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 	//var/obj/screen/inv_sight = null
 
 	var/killswitch = 0 //Used to stop mommis from escape their z-level
-	var/allowed_z = 1
+	var/allowed_z = list()
 	var/finalized = 0 //Track if the mommi finished spawning
 	var/generated = 0 //If a mommi spawner spawned it, set this
 
@@ -477,11 +477,15 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 
 */
 /mob/living/silicon/robot/mommi/proc/initialize_killswitch()
-	allowed_z = src.z
+	allowed_z = list()
+	var/spawn_z = src.z
 	var/station_name
-	switch (allowed_z)
+	switch (spawn_z)
 		if(1)
 			station_name = "Space Station 13"
+			allowed_z += 5
+			allowed_z += 2 //For the mining shuttle
+			add_ion_law("The mining asteroid is considered part of the station")
 		if(2)
 			station_name = "Central Command"
 		if(3)
@@ -493,11 +497,13 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 		if(6)
 			station_name = "Deep Space"
 		if(7)
-			station_name = "Deep Space"
+			station_name = "Deeper Space"
 		if(8)
 			station_name = "The Clown Planet"
 		if(9) //away mission
+		//would be nice to have an away_mission_name var to properly name it
 			station_name = "The Away Mission"
+	allowed_z += spawn_z
 	add_ion_law("[station_name] is your station.  Do not leave [station_name].")
 	spawn (10)
 		killswitch = 1

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -30,6 +30,15 @@
 	if(prob(50))
 		qdel(src)
 
+/obj/structure/reagent_dispensers/examine(mob/user)
+	..()
+	user << "<span class='info'>It contains:</span>"
+	if(reagents && reagents.reagent_list.len)
+		for(var/datum/reagent/R in reagents.reagent_list)
+			user << "<span class='info'>[R.volume] units of [R.name]</span>"
+	else
+		user << "<span class='info'>Nothing.</span>"
+
 /obj/structure/reagent_dispensers/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	return
 
@@ -96,17 +105,12 @@
 		reagents.add_reagent("fuel",1000)
 
 
-/obj/structure/reagent_dispensers/fueltank/examine()
-	set src in oview()
-	var/msg
-	msg += desc
-	if(modded)
-		msg += "<cpan class ='danger> The fuel faucet is wrenched open, leaking the fuel! </span>"
+/obj/structure/reagent_dispensers/fueltank/examine(mob/user)
+	..()
+	if (modded)
+		user << "<span class='warning'>The fuel faucet is wrenched open, leaking the fuel!</span>"
 	if(rig)
-		msg += "<span class='notice'>There is some kind of device rigged to the tank. </span>"
-	usr << msg
-	return
-
+		user << "<span class='notice'>There is some kind of device rigged to the tank.</span>"
 
 
 
@@ -131,7 +135,7 @@
 		user.visible_message("[user] wrenches [src]'s faucet [modded ? "closed" : "open"].", \
 		"You wrench [src]'s faucet [modded ? "closed" : "open"]")
 		modded = modded ? 0 : 1
-	if (istype(W,/obj/item/device/assembly_holder) && modded)
+	if (istype(W,/obj/item/device/assembly_holder))
 		if (ismommi(user))
 			var/mob/living/silicon/robot/mommi/M = user
 			if(M.keeper)


### PR DESCRIPTION
Removes the ability of keeper MoMMIs to strip and pull mobs, properly destroys derelict MoMMIs when they gib, allows station MoMMIs to travel to the mining asteroid, and fixes the description of fuel tanks
