### PR TITLE
Allow player to cancel prepared but not started surgeries with drapes

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -15,6 +15,10 @@
 /mob/living/carbon/attackby(obj/item/I, mob/user, params)
 	if(lying || isslime(src))
 		if(surgeries.len)
+			if(istype(I, /obj/item/weapon/surgical_drapes) || istype(I, /obj/item/weapon/bedsheet))
+				for(var/datum/surgery/S in surgeries)
+					S.cancel(user, src)
+					return 1
 			if(user.a_intent == "help")
 				for(var/datum/surgery/S in surgeries)
 					if(S.next_step(user, src))

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -31,6 +31,21 @@
 	target.surgeries -= src
 	src = null
 
+/datum/surgery/proc/cancel(var/mob/user, var/mob/living/carbon/human/target)
+	if(src.can_cancel())
+		target.surgeries -= src
+		user << "<span class='warning'>You cancel the [src].</span>"
+		src = null
+
+	else
+		user << "<span class='warning'>You can't cancel the [src].</span>" //Maybe add a explaination that the procedure has already started?
+
+/datum/surgery/proc/can_cancel() //Can be overriden on specific surgeries so you could cancel them at a later step (like augging etc,)
+	if(status < 2) //If the procedure hasn't been started
+		return 1
+	return 0
+
+
 
 
 //INFO


### PR DESCRIPTION
You can still do one step to stop their cancelation, but that could be overriden for the augging operations
