### PR TITLE
Airlock deconstruction edit

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -34,6 +34,7 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 /datum/wires/airlock/GetInteractWindow()
 	var/obj/machinery/door/airlock/A = holder
 	. += ..()
+	. += "<A href='?src=\ref[src];action=1;electronics=1'>Remove electronics</A>"
 	. += text("<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]", (A.locked ? "The door bolts have fallen!" : "The door bolts look up."),
 	(A.lights ? "The door bolt lights are on." : "The door bolt lights are off!"),
 	((A.hasPower()) ? "The test light is on." : "The test light is off!"),
@@ -41,6 +42,23 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 	(A.safe==0 ? "The 'Check Wiring' light is on." : "The 'Check Wiring' light is off."),
 	(A.normalspeed==0 ? "The 'Check Timing Mechanism' light is on." : "The 'Check Timing Mechanism' light is off."),
 	(A.emergency==0 ? "The emergency lights are off." : "The emergency lights are on."))
+
+/datum/wires/airlock/Topic(href, href_list)	//Todo: close window if electronics are removed
+	..()
+	if(in_range(holder, usr) && isliving(usr))
+
+		var/mob/living/L = usr
+		if(CanUse(L) && href_list["action"])
+			var/obj/item/I = L.get_active_hand()
+			holder.add_hiddenprint(L)
+			if(href_list["electronics"]) // Removes electronics
+				if(istype(I, /obj/item/weapon/screwdriver))
+					var/obj/machinery/door/airlock/A = holder
+					if(!A.shock(L, 50))
+						playsound(A.loc, 'sound/items/Screwdriver.ogg', 100, 1)
+						A.remove_electronics(L)
+				else
+					L << "<span class='error'>You need a screwdriver!</span>"
 
 /datum/wires/airlock/UpdateCut(var/index, var/mended)
 

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -43,7 +43,7 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 	(A.normalspeed==0 ? "The 'Check Timing Mechanism' light is on." : "The 'Check Timing Mechanism' light is off."),
 	(A.emergency==0 ? "The emergency lights are off." : "The emergency lights are on."))
 
-/datum/wires/airlock/Topic(href, href_list)	//Todo: close window if electronics are removed
+/datum/wires/airlock/Topic(href, href_list)
 	..()
 	if(in_range(holder, usr) && isliving(usr))
 
@@ -51,7 +51,7 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 		if(CanUse(L) && href_list["action"])
 			var/obj/item/I = L.get_active_hand()
 			holder.add_hiddenprint(L)
-			if(href_list["electronics"]) // Removes electronics
+			if(href_list["electronics"]) // Removes electronics. Todo: close window afterwards
 				if(istype(I, /obj/item/weapon/screwdriver))
 					var/obj/machinery/door/airlock/A = holder
 					if(!A.shock(L, 50))

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -51,12 +51,14 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 		if(CanUse(L) && href_list["action"])
 			var/obj/item/I = L.get_active_hand()
 			holder.add_hiddenprint(L)
-			if(href_list["electronics"]) // Removes electronics. Todo: close window afterwards
+			if(href_list["electronics"])
 				if(istype(I, /obj/item/weapon/screwdriver))
 					var/obj/machinery/door/airlock/A = holder
 					if(!A.shock(L, 50))
 						playsound(A.loc, 'sound/items/Screwdriver.ogg', 100, 1)
-						A.remove_electronics(L)
+						if(A.remove_electronics(L))
+							src.Topic("close=1", params2list("close=1"))	//Closes the window. Duh
+							return
 				else
 					L << "<span class='error'>You need a screwdriver!</span>"
 

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -34,6 +34,7 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 /datum/wires/airlock/GetInteractWindow()
 	var/obj/machinery/door/airlock/A = holder
 	. += ..()
+	. += "<A href='?src=\ref[src];action=1;electronics=1'>Remove electronics</A>"
 	. += text("<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]", (A.locked ? "The door bolts have fallen!" : "The door bolts look up."),
 	(A.lights ? "The door bolt lights are on." : "The door bolt lights are off!"),
 	((A.hasPower()) ? "The test light is on." : "The test light is off!"),
@@ -41,6 +42,25 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 	(A.safe==0 ? "The 'Check Wiring' light is on." : "The 'Check Wiring' light is off."),
 	(A.normalspeed==0 ? "The 'Check Timing Mechanism' light is on." : "The 'Check Timing Mechanism' light is off."),
 	(A.emergency==0 ? "The emergency lights are off." : "The emergency lights are on."))
+
+/datum/wires/airlock/Topic(href, href_list)
+	..()
+	if(in_range(holder, usr) && isliving(usr))
+
+		var/mob/living/L = usr
+		if(CanUse(L) && href_list["action"])
+			var/obj/item/I = L.get_active_hand()
+			holder.add_hiddenprint(L)
+			if(href_list["electronics"]) // Removes electronics
+				if(istype(I, /obj/item/weapon/screwdriver))
+					var/obj/machinery/door/airlock/A = holder
+					if(!A.shock(L, 50))
+						playsound(A.loc, 'sound/items/Screwdriver.ogg', 100, 1)
+						A.remove_electronics(L)
+				else
+					L << "<span class='error'>You need a screwdriver!</span>"
+			Interact(usr)
+
 
 /datum/wires/airlock/UpdateCut(var/index, var/mended)
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -926,34 +926,7 @@ About the new airlock wires panel:
 			beingcrowbarred = 0
 		if( beingcrowbarred && (density && welded && !operating && src.p_open && (!hasPower()) && !src.locked) )
 			playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-			user.visible_message("<span class='warning'>[user] removes the electronics from the airlock assembly.</span>", \
-								 "You start to remove electronics from the airlock assembly.")
-			if(do_after(user,40))
-				if(src.loc)
-					if(src.doortype)
-						new src.doortype(src.loc)
-
-					if(emagged)
-						user << "<span class='warning'>You discard the damaged electronics.</span>"
-						qdel(src)
-						return
-					user << "<span class='notice'>You removed the airlock electronics!</span>"
-
-					var/obj/item/weapon/airlock_electronics/ae
-					if(!electronics)
-						ae = new/obj/item/weapon/airlock_electronics( src.loc )
-						if(req_one_access)
-							ae.use_one_access = 1
-							ae.conf_access = src.req_one_access
-						else
-							ae.conf_access = src.req_access
-					else
-						ae = electronics
-						electronics = null
-						ae.loc = src.loc
-
-					qdel(src)
-					return
+			remove_electronics(user)
 		else if(hasPower())
 			user << "<span class='warning'> The airlock's motors resist your efforts to force it.</span>"
 		else if(locked)
@@ -983,6 +956,36 @@ About the new airlock wires panel:
 	else
 		..()
 	return
+
+/obj/machinery/door/airlock/proc/remove_electronics(mob/user as mob)
+	user.visible_message("<span class='warning'>[user] removes the electronics from the airlock assembly.</span>", \
+								 "You start to remove electronics from the airlock assembly.")
+	if(do_after(user,40))
+		if(src.loc)
+			if(src.doortype)
+				new src.doortype(src.loc)
+
+			if(emagged)
+				user << "<span class='warning'>You discard the damaged electronics.</span>"
+				qdel(src)
+				return
+			user << "<span class='notice'>You removed the airlock electronics!</span>"
+
+			var/obj/item/weapon/airlock_electronics/ae
+			if(!electronics)
+				ae = new/obj/item/weapon/airlock_electronics( src.loc )
+				if(req_one_access)
+					ae.use_one_access = 1
+					ae.conf_access = src.req_one_access
+				else
+					ae.conf_access = src.req_access
+			else
+				ae = electronics
+				electronics = null
+				ae.loc = src.loc
+
+			qdel(src)
+			return
 
 /obj/machinery/door/airlock/plasma/attackby(C as obj, mob/user as mob, params)
 	if(is_hot(C) > 300)//If the temperature of the object is over 300, then ignite

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -968,7 +968,7 @@ About the new airlock wires panel:
 			if(emagged)
 				user << "<span class='warning'>You discard the damaged electronics.</span>"
 				qdel(src)
-				return
+				return 1
 			user << "<span class='notice'>You removed the airlock electronics!</span>"
 
 			var/obj/item/weapon/airlock_electronics/ae
@@ -985,7 +985,9 @@ About the new airlock wires panel:
 				ae.loc = src.loc
 
 			qdel(src)
-			return
+			return 1
+	else
+		return 0
 
 /obj/machinery/door/airlock/plasma/attackby(C as obj, mob/user as mob, params)
 	if(is_hot(C) > 300)//If the temperature of the object is over 300, then ignite

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -926,34 +926,7 @@ About the new airlock wires panel:
 			beingcrowbarred = 0
 		if( beingcrowbarred && (density && welded && !operating && src.p_open && (!hasPower()) && !src.locked) )
 			playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-			user.visible_message("<span class='warning'>[user] removes the electronics from the airlock assembly.</span>", \
-								 "You start to remove electronics from the airlock assembly.")
-			if(do_after(user,40))
-				if(src.loc)
-					if(src.doortype)
-						new src.doortype(src.loc)
-
-					if(emagged)
-						user << "<span class='warning'>You discard the damaged electronics.</span>"
-						qdel(src)
-						return
-					user << "<span class='notice'>You removed the airlock electronics!</span>"
-
-					var/obj/item/weapon/airlock_electronics/ae
-					if(!electronics)
-						ae = new/obj/item/weapon/airlock_electronics( src.loc )
-						if(req_one_access)
-							ae.use_one_access = 1
-							ae.conf_access = src.req_one_access
-						else
-							ae.conf_access = src.req_access
-					else
-						ae = electronics
-						electronics = null
-						ae.loc = src.loc
-
-					qdel(src)
-					return
+			remove_electronics(user)
 		else if(hasPower())
 			user << "<span class='warning'> The airlock's motors resist your efforts to force it.</span>"
 		else if(locked)
@@ -983,6 +956,37 @@ About the new airlock wires panel:
 	else
 		..()
 	return
+
+
+/obj/machinery/door/airlock/proc/remove_electronics(mob/user as mob)
+	user.visible_message("<span class='warning'>[user] removes the electronics from the airlock assembly.</span>", \
+								 "You start to remove electronics from the airlock assembly.")
+	if(do_after(user,40))
+		if(src.loc)
+			if(src.doortype)
+				new src.doortype(src.loc)
+
+			if(emagged)
+				user << "<span class='warning'>You discard the damaged electronics.</span>"
+				qdel(src)
+				return
+			user << "<span class='notice'>You removed the airlock electronics!</span>"
+
+			var/obj/item/weapon/airlock_electronics/ae
+			if(!electronics)
+				ae = new/obj/item/weapon/airlock_electronics( src.loc )
+				if(req_one_access)
+					ae.use_one_access = 1
+					ae.conf_access = src.req_one_access
+				else
+					ae.conf_access = src.req_access
+			else
+				ae = electronics
+				electronics = null
+				ae.loc = src.loc
+
+			qdel(src)
+			return
 
 /obj/machinery/door/airlock/plasma/attackby(C as obj, mob/user as mob, params)
 	if(is_hot(C) > 300)//If the temperature of the object is over 300, then ignite


### PR DESCRIPTION
Airlock electronics can be removed with a screwdriver when the panel is open, making deconstruction and fixing emagged doors easier
